### PR TITLE
update s3 url to point to assets.csh

### DIFF
--- a/audiophiler/templates/base.html
+++ b/audiophiler/templates/base.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="theme-color" content="#B0197E">
-    <link rel="stylesheet" href="https://s3.csh.rit.edu/csh-material-bootstrap/3.3.6/dist/csh-material-bootstrap.min.css">
+    <link rel="stylesheet" href="https://assets.csh.rit.edu/csh-material-bootstrap/3.3.6/dist/csh-material-bootstrap.min.css">
     <link rel="stylesheet" href="/static/css/styles.css">
     <link rel="manifest" href="/static/manifest.json">
     <link rel="shortcut icon" href="/static/images/favicon.ico" type="image/x-icon">


### PR DESCRIPTION
update asset URL's to make use of the caching and other improvements provided through assets.csh.rit.edu

fixes #34
fixes #36 


